### PR TITLE
Redirect tests

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,11 @@ Router.map(function() {
     this.route('status-code');
   });
 
+  this.route('redirects', function() {
+    this.route('transition-to');
+    this.route('replace-with');
+  });
+
   this.route('not-found', { path: '/*path' });
 });
 

--- a/tests/dummy/app/routes/redirects/replace-with.js
+++ b/tests/dummy/app/routes/redirects/replace-with.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  redirect() {
+    this.replaceWith('/');
+  }
+});

--- a/tests/dummy/app/routes/redirects/transition-to.js
+++ b/tests/dummy/app/routes/redirects/transition-to.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  redirect() {
+    this.transitionTo('/');
+  }
+});

--- a/tests/fastboot/redirects-test.js
+++ b/tests/fastboot/redirects-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
+
+module('FastBoot | redirects test', function(hooks) {
+  setup(hooks);
+
+  test('redirects with a transition to', async function(assert) {
+    let { headers, statusCode, url } = await visit('/redirects/transition-to');
+
+    assert.equal(statusCode, 307);
+    assert.equal(url, '/');
+    assert.equal(headers.location, '//ember-cli-fastboot-testing.localhost/');
+  });
+
+  test('redirects with a replace with', async function(assert) {
+    let { headers, statusCode, url } = await visit('/redirects/replace-with');
+
+    assert.equal(statusCode, 307);
+    assert.equal(url, '/');
+    assert.equal(headers.location, '//ember-cli-fastboot-testing.localhost/');
+  });
+
+});


### PR DESCRIPTION
Adds tests for `transitionTo` and `replaceWith` status codes.

https://github.com/embermap/ember-cli-fastboot-testing/issues/6

https://github.com/embermap/ember-cli-fastboot-testing/issues/4