### PR TITLE
Preserve query parameters

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -12,7 +12,8 @@ export function setup(hooks) {
 }
 
 export async function fastboot(url) {
-  let endpoint = `/__fastboot-testing?url=${url}`;
+  let encodedURL = encodeURIComponent(url);
+  let endpoint = `/__fastboot-testing?url=${encodedURL}`;
   let response = await fetch(endpoint);
   let result = await response.json();
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
 
   _fastbootRenderingMiddleware(app) {
     app.use('/__fastboot-testing', (req, res) => {
+      let url = decodeURIComponent(req.query.url);
       let options = {
         request: {
           headers: {
@@ -29,7 +30,7 @@ module.exports = {
       };
 
       this.fastboot
-        .visit(req.query.url, options)
+        .visit(url, options)
         .then(page => {
           page.html().then(html => {
             res.json({

--- a/tests/dummy/app/controllers/query-parameters.js
+++ b/tests/dummy/app/controllers/query-parameters.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['first', 'second', 'third'],
+  first: null,
+  second: null,
+  third: null,
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -21,6 +21,8 @@ Router.map(function() {
     this.route('replace-with');
   });
 
+  this.route('query-parameters');
+
   this.route('not-found', { path: '/*path' });
 });
 

--- a/tests/dummy/app/templates/query-parameters.hbs
+++ b/tests/dummy/app/templates/query-parameters.hbs
@@ -1,0 +1,1 @@
+<h1>{{first}} {{second}} {{third}}</h1>

--- a/tests/fastboot/basic-test.js
+++ b/tests/fastboot/basic-test.js
@@ -30,4 +30,9 @@ module('Fastboot | basic', function(hooks) {
     assert.equal(statusCode, 200);
   });
 
+  test('it preserves all query parameters', async function(assert) {
+    await visit('/query-parameters?first=1&second=2&third=3');
+
+    assert.dom('h1').hasText('1 2 3');
+  });
 });


### PR DESCRIPTION
Since ember-cli-fastboot-testing is appending `visit`ed URLs to `__fastboot-testing?url=`, all but first query parameter are lost in the process, because they're being passed to the testing endpoint instead of the FastBoot app.

This PR ensures that all query parameters are being preserved by encoding visited URLs (using `encodeURIComponent`).