### PR TITLE
Add values to the request object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
 let FastBoot = require('fastboot');
+let url = require('url');
 
 module.exports = {
   name: 'ember-cli-fastboot-testing',
 
   isDevelopingAddon() {
-    return true;
+    return false;
   },
 
   serverMiddleware(options) {
@@ -19,9 +20,15 @@ module.exports = {
 
   _fastbootRenderingMiddleware(app) {
     app.use('/__fastboot-testing', (req, res) => {
-      let url = decodeURIComponent(req.query.url);
+      let urlToVisit = decodeURIComponent(req.query.url);
+      let parsed = url.parse(urlToVisit, true);
+
       let options = {
         request: {
+          method: 'GET',
+          protocol: 'http',
+          url: parsed.path,
+          query: parsed.query,
           headers: {
             host: 'ember-cli-fastboot-testing.localhost'
           }
@@ -30,7 +37,7 @@ module.exports = {
       };
 
       this.fastboot
-        .visit(url, options)
+        .visit(urlToVisit, options)
         .then(page => {
           page.html().then(html => {
             res.json({

--- a/tests/dummy/app/controllers/request-object.js
+++ b/tests/dummy/app/controllers/request-object.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { readOnly } from '@ember/object/computed';
+
+export default Controller.extend({
+  fastboot: service(),
+
+  request: readOnly('fastboot.request')
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -23,6 +23,8 @@ Router.map(function() {
 
   this.route('query-parameters');
 
+  this.route('request-object');
+
   this.route('not-found', { path: '/*path' });
 });
 

--- a/tests/dummy/app/templates/request-object.hbs
+++ b/tests/dummy/app/templates/request-object.hbs
@@ -1,0 +1,80 @@
+<h1>The request object</h1>
+
+<table>
+
+  <tr>
+    <th>
+      Host
+    </th>
+    <td data-test-id="host">
+      {{request.host}}
+    </td>
+  </tr>
+
+  <tr>
+    <th>
+      Protocol
+    </th>
+    <td data-test-id="protocol">
+      {{request.protocol}}
+    </td>
+  </tr>
+
+  <tr>
+    <th>
+      Headers
+    </th>
+    <td data-test-id="headers">
+      {{#each-in request.headers.headers as |header value|}}
+        <div>
+          {{header}}: {{value}}
+        </div>
+      {{/each-in}}
+    </td>
+  </tr>
+
+  <tr>
+    <th>
+      Query params
+    </th>
+    <td data-test-id="query-params">
+      {{#each-in request.queryParams as |param value|}}
+        <div>
+          {{param}}: {{value}}
+        </div>
+      {{/each-in}}
+    </td>
+  </tr>
+
+  <tr>
+    <th>
+      Path
+    </th>
+    <td data-test-id="path">
+      {{request.path}}
+    </td>
+  </tr>
+
+  <tr>
+    <th>
+      Method
+    </th>
+    <td data-test-id="method">
+      {{request.method}}
+    </td>
+  </tr>
+
+  <tr>
+    <th>
+      Cookies
+    </th>
+    <td>
+      {{#each-in request.cookies as |cookie value|}}
+        <div>
+          {{cookie}}: {{value}}
+        </div>
+      {{/each-in}}
+    </td>
+  </tr>
+
+</table>

--- a/tests/fastboot/request-object-test.js
+++ b/tests/fastboot/request-object-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
+
+module('FastBoot | request object test', function(hooks) {
+  setup(hooks);
+
+  test('it has a host', async function(assert) {
+    await visit('/request-object');
+
+    assert
+      .dom('[data-test-id=host]')
+      .includesText('ember-cli-fastboot-testing.localhost');
+  });
+
+  test('it has a protocol', async function(assert) {
+    await visit('/request-object');
+
+    assert
+      .dom('[data-test-id=protocol]')
+      .includesText('http:');
+  });
+
+  test('it has headers', async function(assert) {
+    await visit('/request-object');
+
+    assert
+      .dom('[data-test-id=headers]')
+      .includesText('host: ember-cli-fastboot-testing.localhost');
+  });
+
+  test('it has query params', async function(assert) {
+    await visit('/request-object?testing=true');
+
+    assert
+      .dom('[data-test-id=query-params]')
+      .includesText('testing: true');
+  });
+
+  test('it has a path', async function(assert) {
+    await visit('/request-object');
+
+    assert
+      .dom('[data-test-id=path]')
+      .includesText('/request-object');
+  });
+
+  test('it has a method', async function(assert) {
+    await visit('/request-object');
+
+    assert
+      .dom('[data-test-id=method]')
+      .includesText('GET');
+  });
+});


### PR DESCRIPTION
Add data to the request object so fastboot apps that depend on the request at runtime get some useful values.

This PR only adds data, it does not provide a way to customize the request. 

Addresses: https://github.com/embermap/ember-cli-fastboot-testing/issues/1

