### PR TITLE
Include user agent in fastboot request header

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = {
           url: parsed.path,
           query: parsed.query,
           headers: {
-            host: 'ember-cli-fastboot-testing.localhost'
+            host: 'ember-cli-fastboot-testing.localhost',
+            'user-agent': 'ember-cli-fastboot-testing'
           }
         },
         response: {}

--- a/tests/fastboot/request-object-test.js
+++ b/tests/fastboot/request-object-test.js
@@ -28,6 +28,14 @@ module('FastBoot | request object test', function(hooks) {
       .includesText('host: ember-cli-fastboot-testing.localhost');
   });
 
+  test('it has user agent in headers', async function(assert) {
+    await visit('/request-object');
+
+    assert
+      .dom('[data-test-id=headers]')
+      .includesText('user-agent: ember-cli-fastboot-testing');
+  });
+
   test('it has query params', async function(assert) {
     await visit('/request-object?testing=true');
 


### PR DESCRIPTION
[ember-useragent](https://github.com/willviles/ember-useragent) (which is a dependency of the pretty popular [ember-table](https://github.com/Addepar/ember-table)) throws an error on requests without a user agent, causing tests to fail.