### PR TITLE
Request Proxy

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,9 +4,7 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // 'ember-fetch': {
-    //   preferNative: true
-    // }
+
   });
 
   /*

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    // 'ember-fetch': {
+    //   preferNative: true
+    // }
   });
 
   /*

--- a/lib/request-proxy-server.js
+++ b/lib/request-proxy-server.js
@@ -1,0 +1,41 @@
+// This is placed in the testing middleware and relays
+// messages to connected websockets
+
+let WebSocket = require('ws');
+
+// eslint-disable-next-line no-undef
+module.exports = class RequestProxyServer {
+  constructor() {
+    this.wss = new WebSocket.Server({
+      port: 7001
+    });
+  }
+
+  listen() {
+    this.wss.on('connection', (ws) => {
+      ws.isAlive = true;
+      ws.on('pong', function() {
+        this.isAlive = true;
+      });
+
+      ws.on('message', (message) => {
+        this.wss.clients.forEach(client => {
+          client.send(message);
+        });
+      });
+
+      ws.on('close', () => {})
+    });
+
+    let interval = setInterval(() => {
+      this.wss.clients.forEach(ws => {
+        if (ws.isAlive === false) {
+          return ws.terminate();
+        }
+
+        ws.isAlive = false;
+        ws.ping(function() {});
+      });
+    }, 1000);
+  }
+};

--- a/lib/request-proxy-server.js
+++ b/lib/request-proxy-server.js
@@ -20,7 +20,9 @@ module.exports = class RequestProxyServer {
 
       ws.on('message', (message) => {
         this.wss.clients.forEach(client => {
-          client.send(message);
+          if (client !== ws && client.readyState === WebSocket.OPEN) {
+            client.send(message);
+          }
         });
       });
 

--- a/lib/request-proxy.js
+++ b/lib/request-proxy.js
@@ -1,0 +1,63 @@
+// This is subbed in for a fetch request in fastboot, 
+// sending a request through a websocket to the browser to fulfil
+
+let WebSocket = require('ws');
+let RSVP = require('rsvp');
+let { Headers, Response } = require('node-fetch');
+
+// eslint-disable-next-line no-undef
+module.exports = class RequestProxy {
+  constructor(wsUrl) {
+    this.wsUrl = wsUrl;
+  }
+  request(url, options) {
+    return new RSVP.Promise((resolve, reject) => {
+      let ws = new WebSocket(this.wsUrl);
+      ws.on('open', () => {
+        let requestTimeout = setTimeout(() => {
+          reject('client relay failed to respond');
+          ws.terminate();
+        }, 3000);
+
+        ws.on('message', (payload) => {
+          try {
+            let response = JSON.parse(payload);
+
+            if (response.type === 'response') {
+              clearTimeout(requestTimeout);
+
+              let body = response.data.body;
+              let status = response.data.status
+              let statusText = response.data.statusText;
+
+              let headers = new Headers();
+              for (let key in response.headers) {
+                headers.append(key, response.headers[key]);
+              }
+
+              resolve(new Response(body, {
+                status,
+                statusText,
+                headers
+              }));
+
+              ws.terminate();
+            }
+          }
+          catch(e) {
+            // eslint-disable-next-line no-console
+            console.error(e);
+          }
+        });
+
+        let data = JSON.stringify({
+          type: 'request',
+          url,
+          options
+        });
+
+        ws.send(data); // request data from client
+      });
+    })
+  }
+};

--- a/package.json
+++ b/package.json
@@ -58,16 +58,16 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",
-    "qunit-dom": "^0.6.2"
+    "qunit-dom": "^0.6.2",
+    "ws": "^6.1.0"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "before": [
+    "after": [
       "ember-cli-fastboot"
-    ],
-    "after": []
+    ]
   }
 }

--- a/tests/dummy/app/initializers/ajax.js
+++ b/tests/dummy/app/initializers/ajax.js
@@ -1,0 +1,14 @@
+var ajaxStub = function (options) {
+  throw options;
+};
+
+export default {
+  name: 'ajax-service',
+  initialize: function (application) {
+    application.register('ajax:node', ajaxStub , {
+      instantiate: false
+    });
+    application.inject('adapter', '_ajaxRequest', 'ajax:node');
+    application.inject('adapter', 'fastboot', 'service:fastboot');
+  }
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -27,6 +27,12 @@ Router.map(function() {
   this.route('external-request');
 
   this.route('not-found', { path: '/*path' });
+
+  this.route('externals', function() {
+    this.route('native-fetch-get');
+    this.route('native-fetch-post');
+    this.route('ember-fetch-get');
+  });
 });
 
 export default Router;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -24,6 +24,7 @@ Router.map(function() {
   this.route('query-parameters');
 
   this.route('request-object');
+  this.route('external-request');
 
   this.route('not-found', { path: '/*path' });
 });

--- a/tests/dummy/app/routes/external-request.js
+++ b/tests/dummy/app/routes/external-request.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+// import fetch from 'fetch';
+import { hash } from 'rsvp'
+export default Route.extend({
+  async model() {
+    return hash({
+      posts: fetch('https://jsonplaceholder.typicode.com/posts').then(response => {
+        return response.json()
+      })
+    });
+  }
+});

--- a/tests/dummy/app/routes/externals/ember-fetch-get.js
+++ b/tests/dummy/app/routes/externals/ember-fetch-get.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+import { hash } from 'rsvp'
+export default Route.extend({
+  async model() {
+    return hash({
+      posts: fetch('https://jsonplaceholder.typicode.com/posts').then(response => {
+        return response.json()
+      })
+    });
+  }
+});

--- a/tests/dummy/app/routes/externals/native-fetch-get.js
+++ b/tests/dummy/app/routes/externals/native-fetch-get.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { hash } from 'rsvp'
+export default Route.extend({
+  async model() {
+    return hash({
+      posts: fetch('https://jsonplaceholder.typicode.com/posts').then(response => {
+        return response.json()
+      })
+    });
+  }
+});

--- a/tests/dummy/app/routes/externals/native-fetch-post.js
+++ b/tests/dummy/app/routes/externals/native-fetch-post.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+import { hash } from 'rsvp'
+export default Route.extend({
+  async model() {
+    return hash({
+      posts: fetch('https://jsonplaceholder.typicode.com/posts', { method: 'POST' }).then(response => {
+        return response.json()
+      })
+    });
+  }
+});

--- a/tests/dummy/app/templates/external-request.hbs
+++ b/tests/dummy/app/templates/external-request.hbs
@@ -1,0 +1,8 @@
+<h1>external request</h1>
+
+{{#each model.posts as |post|}}
+  <div data-post-id={{post.id}}>
+    <h2>{{post.title}}</h2>
+    <p>{{post.body}}</p>
+  </div>
+{{/each}}

--- a/tests/dummy/app/templates/externals/ember-fetch-get.hbs
+++ b/tests/dummy/app/templates/externals/ember-fetch-get.hbs
@@ -1,0 +1,8 @@
+<h1>ember fetch request</h1>
+
+{{#each model.posts as |post|}}
+<div data-post-id={{post.id}}>
+  <h2>{{post.title}}</h2>
+  <p>{{post.body}}</p>
+</div>
+{{/each}}

--- a/tests/dummy/app/templates/externals/native-fetch-get.hbs
+++ b/tests/dummy/app/templates/externals/native-fetch-get.hbs
@@ -1,0 +1,8 @@
+<h1>native fetch request: get</h1>
+
+{{#each model.posts as |post|}}
+<div data-post-id={{post.id}}>
+  <h2>{{post.title}}</h2>
+  <p>{{post.body}}</p>
+</div>
+{{/each}}

--- a/tests/dummy/app/templates/externals/native-fetch-post.hbs
+++ b/tests/dummy/app/templates/externals/native-fetch-post.hbs
@@ -1,0 +1,8 @@
+<h1>native fetch request: post</h1>
+
+{{#each model.posts as |post|}}
+<div data-post-id={{post.id}}>
+  <h2>{{post.title}}</h2>
+  <p>{{post.body}}</p>
+</div>
+{{/each}}

--- a/tests/fastboot/external-request-test.js
+++ b/tests/fastboot/external-request-test.js
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setup, visit, setHandler } from 'ember-cli-fastboot-testing/test-support';
 
 module('Fastboot | external request', function(hooks) {
@@ -42,7 +42,7 @@ module('Fastboot | external request', function(hooks) {
       .includesText('stubbed-request-handler');
   });
 
-  skip('it handles a fastboot get request using ember fetch', async function (assert) {
+  test('it handles a fastboot get request using ember fetch', async function (assert) {
     setHandler(async ( /* url , options = {} */ ) => {
       return new Response(JSON.stringify([{
         id: 1,

--- a/tests/fastboot/external-request-test.js
+++ b/tests/fastboot/external-request-test.js
@@ -1,18 +1,18 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setup, visit, setHandler } from 'ember-cli-fastboot-testing/test-support';
 
 module('Fastboot | external request', function(hooks) {
   setup(hooks);
 
-  test('it renders an external request', async function(assert) {
-    await visit('/external-request');
+  test('it fulfils a fastboot get request', async function (assert) {
+    await visit('/externals/native-fetch-get');
 
     assert
       .dom('div[data-post-id="1"] h2')
       .includesText('sunt aut facere repellat provident occaecati excepturi optio reprehenderit');
   });
 
-  test('it allows the server request to be stubbed on the client side', async function (assert) {
+  test('it handles a fastboot get request using global fetch', async function (assert) {
     setHandler(async ( /* url , options = {} */ ) => {
       return new Response(JSON.stringify([{
         id: 1,
@@ -20,10 +20,42 @@ module('Fastboot | external request', function(hooks) {
         body: 'bar'
       }]));
     });
-    await visit('/external-request');
+    await visit('/externals/native-fetch-get');
 
     assert
       .dom('div[data-post-id="1"] h2')
       .includesText('stubbed-request-handler');
   });
+
+  test('it handles a fastboot post request using global fetch', async function (assert) {
+    setHandler(async ( /* url , options = {} */ ) => {
+      return new Response(JSON.stringify([{
+        id: 1,
+        title: 'stubbed-request-handler',
+        body: 'bar'
+      }]));
+    });
+    await visit('/externals/native-fetch-post');
+
+    assert
+      .dom('div[data-post-id="1"] h2')
+      .includesText('stubbed-request-handler');
+  });
+
+  skip('it handles a fastboot get request using ember fetch', async function (assert) {
+    setHandler(async ( /* url , options = {} */ ) => {
+      return new Response(JSON.stringify([{
+        id: 1,
+        title: 'stubbed-request-handler',
+        body: 'bar'
+      }]));
+    });
+
+    await visit('/externals/ember-fetch-get');
+
+    assert
+      .dom('div[data-post-id="1"] h2')
+      .includesText('stubbed-request-handler');
+  });
+
 });

--- a/tests/fastboot/external-request-test.js
+++ b/tests/fastboot/external-request-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setup, visit, setHandler } from 'ember-cli-fastboot-testing/test-support';
+
+module('Fastboot | external request', function(hooks) {
+  setup(hooks);
+
+  test('it renders an external request', async function(assert) {
+    await visit('/external-request');
+
+    assert
+      .dom('div[data-post-id="1"] h2')
+      .includesText('sunt aut facere repellat provident occaecati excepturi optio reprehenderit');
+  });
+
+  test('it allows the server request to be stubbed on the client side', async function (assert) {
+    setHandler(async ( /* url , options = {} */ ) => {
+      return new Response(JSON.stringify([{
+        id: 1,
+        title: 'stubbed-request-handler',
+        body: 'bar'
+      }]));
+    });
+    await visit('/external-request');
+
+    assert
+      .dom('div[data-post-id="1"] h2')
+      .includesText('stubbed-request-handler');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,6 +1636,16 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
+broccoli-plugin@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
+  integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
+  dependencies:
+    promise-map-series "^0.2.1"
+    quick-temp "^0.1.3"
+    rimraf "^2.3.4"
+    symlink-or-copy "^1.1.8"
+
 broccoli-rollup@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz#43a0a7798555bab54217009eb470a4ff5a056df0"
@@ -1805,16 +1815,15 @@ broccoli-templater@^1.0.0:
     lodash.template "^3.3.2"
 
 broccoli-templater@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/broccoli-templater/-/broccoli-templater-2.0.1.tgz#2e001e45aeba7fa2eb9b19a54c9c61b741935799"
-  integrity sha1-LgAeRa66f6LrmxmlTJxht0GTV5k=
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/broccoli-templater/-/broccoli-templater-2.0.2.tgz#285a892071c0b3ad5ebc275d9e8b3465e2d120d6"
+  integrity sha512-71KpNkc7WmbEokTQpGcbGzZjUIY1NSVa3GB++KFKAfx5SZPUozCOsBlSTwxcv8TLoCAqbBnsX5AQPgg6vJ2l9g==
   dependencies:
-    broccoli-persistent-filter "^1.4.3"
-    broccoli-plugin "^1.3.0"
-    fs-tree-diff "^0.5.7"
+    broccoli-plugin "^1.3.1"
+    fs-tree-diff "^0.5.9"
     lodash.template "^4.4.0"
     rimraf "^2.6.2"
-    walk-sync "^0.3.2"
+    walk-sync "^0.3.3"
 
 broccoli-uglify-sourcemap@^2.1.1:
   version "2.2.0"
@@ -4718,6 +4727,16 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz#315e2b098d5fe7f622880ac965b1b051868ac871"
   integrity sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==
+  dependencies:
+    heimdalljs-logger "^0.1.7"
+    object-assign "^4.1.0"
+    path-posix "^1.0.0"
+    symlink-or-copy "^1.1.8"
+
+fs-tree-diff@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz#a4ec6182c2f5bd80b9b83c8e23e4522e6f5fd946"
+  integrity sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==
   dependencies:
     heimdalljs-logger "^0.1.7"
     object-assign "^4.1.0"
@@ -9880,6 +9899,14 @@ walk-sync@^0.2.5, walk-sync@^0.2.7:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
+walk-sync@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.3.tgz#1e9f12cd4fe6e0e6d4a0715b5cc7e30711d43cd1"
+  integrity sha512-jQgTHmCazUngGqvHZFlr30u2VLKEKErBMLFe+fBl5mn4rh9aI/QVRog8PT1hv2vaOu4EBwigfmpRTyZrbnpRVA==
+  dependencies:
+    ensure-posix-path "^1.0.0"
+    matcher-collection "^1.0.0"
+
 walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -10068,6 +10095,13 @@ ws@^4.0.0:
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
+
+ws@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.0.tgz#119a9dbf92c54e190ec18d10e871d55c95cf9373"
+  integrity sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==
+  dependencies:
+    async-limiter "~1.0.0"
 
 ws@~3.3.1:
   version "3.3.3"


### PR DESCRIPTION
Hey @ryanto and @samselikoff!

After I'd been struggling to get [mirage to run in fastboot](https://github.com/samselikoff/ember-cli-mirage/pull/1014#issuecomment-436472540), @mixonic had an idea to instead create a websocket connection between node and the browser, and then send requests up to the browser to get fulfilled. This should allow mirage to keep running in the client where it belongs, while allowing data to be stubbed out and tested in fastboot using this addon.

There's some hurdles still to be overcome, but I wanted to get it on your radar sooner rather than later. What do y'all think of this approach? 

Still to do on this branch:
- Currently I'm stubbing out the global `fetch` in the fastboot environment, but need to figure out a way to make this work in other cases, like when using `ember-fetch`, for example.