### PR TITLE
Fix host port

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,9 @@ module.exports = function(environment, appConfig) {
     appConfig.fastboot = appConfig.fastboot || {};
     appConfig.fastboot.hostWhitelist = appConfig.fastboot.hostWhitelist || [];
 
-    appConfig.fastboot.hostWhitelist.push('ember-cli-fastboot-testing.localhost');
+    if (!appConfig.fastboot.hostWhitelist.includes('localhost')) {
+      appConfig.fastboot.hostWhitelist.push('localhost');
+    }
   }
 
   return { };

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,10 +4,7 @@ module.exports = function(environment, appConfig) {
   if (environment === 'test') {
     appConfig.fastboot = appConfig.fastboot || {};
     appConfig.fastboot.hostWhitelist = appConfig.fastboot.hostWhitelist || [];
-
-    if (!appConfig.fastboot.hostWhitelist.includes('localhost')) {
-      appConfig.fastboot.hostWhitelist.push('localhost');
-    }
+    appConfig.fastboot.hostWhitelist.push(/localhost:\d+$/);
   }
 
   return { };

--- a/index.js
+++ b/index.js
@@ -23,9 +23,7 @@ module.exports = {
       let urlToVisit = decodeURIComponent(req.query.url);
       let parsed = url.parse(urlToVisit, true);
 
-      let defaults = {
-        host: 'ember-cli-fastboot-testing.localhost'
-      }
+      let defaults = {};
 
       let headers = Object.assign(req.headers, defaults, req.query.headers);
 

--- a/tests/fastboot/redirects-test.js
+++ b/tests/fastboot/redirects-test.js
@@ -9,7 +9,7 @@ module('FastBoot | redirects test', function(hooks) {
 
     assert.equal(statusCode, 307);
     assert.equal(url, '/');
-    assert.equal(headers.location, '//ember-cli-fastboot-testing.localhost/');
+    assert.equal(headers.location, `//${window.location.host}/`);
   });
 
   test('redirects with a replace with', async function(assert) {
@@ -17,7 +17,7 @@ module('FastBoot | redirects test', function(hooks) {
 
     assert.equal(statusCode, 307);
     assert.equal(url, '/');
-    assert.equal(headers.location, '//ember-cli-fastboot-testing.localhost/');
+    assert.equal(headers.location, `//${window.location.host}/`);
   });
 
 });

--- a/tests/fastboot/request-object-test.js
+++ b/tests/fastboot/request-object-test.js
@@ -9,7 +9,7 @@ module('FastBoot | request object test', function(hooks) {
 
     assert
       .dom('[data-test-id=host]')
-      .includesText('ember-cli-fastboot-testing.localhost');
+      .includesText('localhost:7357');
   });
 
   test('it has a protocol', async function(assert) {
@@ -25,7 +25,7 @@ module('FastBoot | request object test', function(hooks) {
 
     assert
       .dom('[data-test-id=headers]')
-      .includesText('host: ember-cli-fastboot-testing.localhost');
+      .includesText('host: localhost');
   });
 
   test('it has user agent in headers', async function(assert) {


### PR DESCRIPTION
Previously the fastboot server would default with a host of `ember-cli-fastboot-testing.localhost`. This made relative ajax requests from an fastboot app difficult to reason about.

Instead we'll `app.visit` the fastboot instance with a host of the browser that's running the fastboot tests.