### PR TITLE
FastBoot testing hooks

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,6 +11,8 @@ Router.map(function() {
     this.route('quickstart');
     this.route('debugging');
     this.route('videos');
+    this.route('hooks');
+    this.route('network-mocking');
     this.route('html');
     this.route('document');
     this.route('status-code');

--- a/tests/dummy/app/templates/docs.hbs
+++ b/tests/dummy/app/templates/docs.hbs
@@ -9,8 +9,10 @@
 
     {{nav.section 'Usage & options'}}
     {{nav.item 'Visit helper' 'docs.visit'}}
+    {{nav.item 'Hooks' 'docs.hooks'}}
 
     {{nav.section 'Tips & tricks'}}
+    {{nav.item 'Network mocking' 'docs.network-mocking'}}
     {{nav.item 'Debugging' 'docs.debugging'}}
     {{nav.item 'Videos' 'docs.videos'}}
 

--- a/tests/dummy/app/templates/docs/hooks.md
+++ b/tests/dummy/app/templates/docs/hooks.md
@@ -1,4 +1,4 @@
-> This code does not exist, we're using this document to help flush out the API for what hooks might look like.
+> This code does not exist, we're using this document to help find the API for what hooks might look like.
 
 # Hooks
 
@@ -30,7 +30,7 @@ To see a full list of configuration options take a look at the [FastBoot documen
 
 The `beforeCreate` is called during your test build right before the FastBoot instance is created.
 
-This hook is a great place for you to setup global testing mocks. See the [networking mocking]() guide for an example of setting up HTTP fixtures with FastBoot testing.
+This hook is a great place for you to setup global testing mocks. See the [networking mocking](network-mocking) guide for an example of setting up HTTP fixtures with FastBoot testing.
 
 ```js
 // config/fastboot-testing-hooks.js
@@ -76,18 +76,18 @@ module.exports = function(hooks) {
 
 By default FastBoot testing runs a single piece of express middleware that renders the FastBoot response. This may differ from your production environment, which might compose multiple piece of middleware around the call to FastBoot.
 
-For example, your production server modify an HTTP request before passing it into FastBoot. Or, once FastBoot generates a response your server might modify that response in some way, for example inlining critical CSS.
+For example, your production server may modify an HTTP request before passing it into FastBoot. Or, once FastBoot generates a response your server might modify that response in some way, for example inlining critical CSS.
 
-In order to give your testing environment more control of it's middleware stack there is a middleware hook.
+In order to give your testing environment more control of it's middleware stack there is the middleware hook.
 
-> Note: This hook requires you to call the FastBoot testing middleware, it's passed in as the first parameter.
+> Note: This hook requires you to call the FastBoot testing middleware, it's passed in as part of the options parameter.
 
 ```js
 // config/fastboot-testing-hooks.js
 
 module.exports = function(hooks) {
 
-  hooks.middleware((fastbootTesting) => {
+  hooks.middleware(({ app, fastbootTesting }) => {
 
     app.use((req, res, next) => {
       req.headers['x-i-came-from-fastboot-testing'] = true;

--- a/tests/dummy/app/templates/docs/hooks.md
+++ b/tests/dummy/app/templates/docs/hooks.md
@@ -1,0 +1,101 @@
+> This code does not exist, we're using this document to help flush out the API for what hooks might look like.
+
+# Hooks
+
+Hooks allow you to run server side node code before and after interacting with the FastBoot instance. Hooks provide a place for:
+
+* Configuring the FastBoot instance
+* Mocking network requests made from FastBoot
+* Adding middleware to the express app
+
+All hooks are defined inside of your application's `config/fastboot-testing-hooks.js` file.
+
+## Config hook
+
+The `defaultConfig` hook lets you define configuration options for creating the FastBoot instance. For example, if you wanted `ember-cli-fastboot-testing` to not fail a test when there is a FastBoot rendering error you can turn on `resilient` mode.
+
+```js
+// config/fastboot-testing-hooks.js
+
+module.exports = function(hooks) {
+  hooks.defaultConfig({
+    resilient: true
+  });
+};
+```
+
+To see a full list of configuration options take a look at the [FastBoot documentation](https://github.com/ember-fastboot/fastboot#additional-configuration).
+
+## Before create hook
+
+The `beforeCreate` is called during your test build right before the FastBoot instance is created.
+
+This hook is a great place for you to setup global testing mocks. See the [networking mocking]() guide for an example of setting up HTTP fixtures with FastBoot testing.
+
+```js
+// config/fastboot-testing-hooks.js
+
+module.exports = function(hooks) {
+
+  hooks.beforeCreate(() => {
+    // This code is run when your test suite finishes building, but
+    // before the FastBoot instance is created.
+
+    // This hook is only ever called once for the entire life cycle
+    // of your test process.
+  });
+
+};
+```
+
+## Visit hooks
+
+The visit hooks will run before and after the `visit` helper generates
+a page in FastBoot. These hooks are best for doing per test HTTP mocking in FastBoot.
+
+```js
+// config/fastboot-testing-hooks.js
+
+module.exports = function(hooks) {
+
+  hooks.beforeVisit(() => {
+    // This code is run right before FastBoot testing visits a URL.
+
+  });
+
+  hooks.afterVisit(() => {
+    // And this code is run after FastBoot has generated a visit
+    // response
+
+  });
+
+};
+```
+
+## Middleware hook
+
+By default FastBoot testing runs a single piece of express middleware that renders the FastBoot response. This may differ from your production environment, which might compose multiple piece of middleware around the call to FastBoot.
+
+For example, your production server modify an HTTP request before passing it into FastBoot. Or, once FastBoot generates a response your server might modify that response in some way, for example inlining critical CSS.
+
+In order to give your testing environment more control of it's middleware stack there is a middleware hook.
+
+> Note: This hook requires you to call the FastBoot testing middleware, it's passed in as the first parameter.
+
+```js
+// config/fastboot-testing-hooks.js
+
+module.exports = function(hooks) {
+
+  hooks.middleware((fastbootTesting) => {
+
+    app.use((req, res, next) => {
+      req.headers['x-i-came-from-fastboot-testing'] = true;
+      next();
+    });
+
+    app.use(fastbootTesting);
+  });
+
+};
+```

--- a/tests/dummy/app/templates/docs/network-mocking.md
+++ b/tests/dummy/app/templates/docs/network-mocking.md
@@ -69,7 +69,7 @@ modules.exports = function(hooks) {
 }
 ```
 
-Next, each of our FastBoot tests can create their own mocks using the `/create-fastboot-testing-mock` endpoint. Here's an exa
+Next, each of our FastBoot tests can create their own mocks using the `/create-fastboot-testing-mock` endpoint. Here's an example:
 
 ```js
 import fetch from 'fetch';

--- a/tests/dummy/app/templates/docs/network-mocking.md
+++ b/tests/dummy/app/templates/docs/network-mocking.md
@@ -1,0 +1,34 @@
+# Network mocking
+
+It's common for Ember test suites to rely on mirage, pretender, or http-mocks to control the HTTP responses given to their application during test.
+
+While these tools work well for mocking HTTP requests in the browser, they do not run inside of node. This makes it difficult to mock the HTTP responses given to a FastBoot server under test.
+
+Fortunately, the node ecosystem has a number of HTTP mocking libraries. For example, [nock](https://github.com/nock/nock) can be used to intercept network requests made from a node application.
+
+## Global responses
+
+This example defines a global endpoint `/hello.json` that will return a JSON response for any FastBoot test.
+
+The `beforeCreate` hook is a good place to load fixtures or define API responses that you would want to exist in every FastBoot test.
+
+```js
+// config/fastboot-testing-hooks.js
+
+let nock = require('nock');
+
+module.exports = function(hooks) {
+
+  hooks.beforeCreate(() => {
+
+    nock.get('/hello.json')
+      .reply(200, { id: 123, message: "hello!" });
+
+  });
+
+};
+```
+
+## Per test responses
+
+> TODO: This is harder!

--- a/tests/dummy/app/templates/docs/network-mocking.md
+++ b/tests/dummy/app/templates/docs/network-mocking.md
@@ -98,7 +98,7 @@ module('FastBoot | The posts page', function(hooks) {
     assert.dom('h1.title').includesText('Hello world!');
   });
 
-  test('it renders a post', async function(assert) {
+  test('it renders an error when the post is not found', async function(assert) {
 
     await fetch("/create-fastboot-testing-mock", {
       method: "post",


### PR DESCRIPTION
This PR has documentation for a hooks feature that will give users of this addon more control over FastBoot testing. Specifically, configuration and access to node-land code where HTTP mocks can be created.

Hooks API: https://embermap.github.io/ember-cli-fastboot-testing/versions/before-create-fastboot-hook/docs/hooks

Network mocking using hooks: https://embermap.github.io/ember-cli-fastboot-testing/versions/before-create-fastboot-hook/docs/network-mocking

I'm not tied to any of these APIs, this is just a brain dump of what the feature could look like. Please feel free to change anything!

After we edit and fine tune these docs we can use them as a roadmap for implementing the feature.