### PR TITLE
Notify if fake server intercepts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  globals: {
+    server: true,
+  },
   root: true,
   parserOptions: {
     ecmaVersion: 2017,

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -28,7 +28,24 @@ export async function fastboot(url, { headers = {} }) {
 }
 
 export async function visit(url, options = {}) {
-  let result = await fastboot(url, { headers: options.headers || {} });
+  let result;
+
+  try {
+    result = await fastboot(url, { headers: options.headers || {} });
+  } catch (e) {
+    let message;
+
+    if (e.message && e.message.match(/^Mirage:/)) {
+      message = `Ember CLI FastBoot Testing: It looks like Mirage is intercepting ember-cli-fastboot-testing's attempt to render ${url}. Please disable Mirage when running FastBoot tests.`;
+      console.error(message);
+      throw new Error(message);
+    } else if (e.message) {
+      message = `Ember CLI FastBoot Testing: generic error`
+    } else {
+
+    }
+
+  }
 
   document.querySelector('#ember-testing').innerHTML = result.body;
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ module.exports = {
         response: {}
       };
 
+      res.set('x-fastboot-testing', true);
+
       this.fastboot
         .visit(urlToVisit, options)
         .then(page => {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",
+    "pretender": "~2.1.0",
     "qunit-dom": "^0.6.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-mirage": "^0.4.15",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,0 +1,26 @@
+export default function() {
+
+  // These comments are here to help you get started. Feel free to delete them.
+
+  /*
+    Config (with defaults).
+
+    Note: these only affect routes defined *after* them!
+  */
+
+  // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
+  // this.namespace = '';    // make this `/api`, for example, if your API is namespaced
+  // this.timing = 400;      // delay for each request, automatically set to 0 during testing
+
+  /*
+    Shorthand cheatsheet:
+
+    this.get('/posts');
+    this.post('/posts');
+    this.get('/posts/:id');
+    this.put('/posts/:id'); // or this.patch
+    this.del('/posts/:id');
+
+    http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/
+  */
+}

--- a/tests/dummy/mirage/scenarios/default.js
+++ b/tests/dummy/mirage/scenarios/default.js
@@ -1,0 +1,9 @@
+export default function(/* server */) {
+
+  /*
+    Seed your development database using your factories.
+    This data will not be loaded in your tests.
+  */
+
+  // server.createList('post', 10);
+}

--- a/tests/dummy/mirage/serializers/application.js
+++ b/tests/dummy/mirage/serializers/application.js
@@ -1,0 +1,4 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+});

--- a/tests/fastboot/basic-test.js
+++ b/tests/fastboot/basic-test.js
@@ -1,14 +1,8 @@
-import { module, test, skip } from 'qunit';
-import { setup, visit, renderedHtml } from 'ember-cli-fastboot-testing/test-support';
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
 
 module('Fastboot | basic', function(hooks) {
   setup(hooks);
-
-  skip('it renders html that matches the browser', async function(assert) {
-    let { body } = await visit('/');
-
-    assert.equal(body, renderedHtml());
-  });
 
   test('it renders the correct h1 title', async function(assert) {
     await visit('/');

--- a/tests/fastboot/generic-interceptors-test.js
+++ b/tests/fastboot/generic-interceptors-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
+import Pretender from 'pretender';
+
+/*
+  This test is setup to emulate the following scenario: Someone is using
+  FastBoot testing as well as an http interceptor for mocking.
+  When FastBoot testing asks ember-cli to render a page, the interceptor
+  will block the http request and attempt to return a mock.
+
+  We'll simulate this by overriding fetch.
+
+  We want to provide a better error message when that happens.
+*/
+module('Fastboot | generic interceptor', function(hooks) {
+  setup(hooks);
+
+  test('it doesnt work if an interceptor blocks our request to ember-cli', async function(assert) {
+    let server = new Pretender(function() {
+      this.get('/__fastboot-testing', () => {
+        throw new Error("Blocked!");
+      });
+    });
+
+    assert.rejects(
+      visit('/'),
+      /We were unable to render \/. Is your test suite blocking or intercepting HTTP requests\? Error: Pretender intercepted GET \/__fastboot-testing\?url=%2F but encountered an error: Blocked/
+    );
+
+    server.shutdown();
+  });
+
+  test('mocked response', function(assert) {
+    let server = new Pretender(function() {
+      this.get('/__fastboot-testing', () => {
+        return [
+          200,
+          {"Content-Type": "application/json"},
+          JSON.stringify({ mocked: true })
+        ];
+      });
+    });
+
+    assert.rejects(
+      visit('/'),
+      /We were unable to render \/. Is your test suite blocking or intercepting HTTP requests\?/
+    );
+
+    server.shutdown();
+  });
+});

--- a/tests/fastboot/http-interceptors-test.js
+++ b/tests/fastboot/http-interceptors-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setup, visit } from 'ember-cli-fastboot-testing/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+
+/*
+  This test is setup to emulate the following scenario: Someone is using
+  FastBoot testing as well as a local mirage server. When FastBoot testing
+  asks ember-cli to render a page, mirage will intercept the http request and
+  then say it didnt know how to handle the request.
+
+  We want to provide a better error message when that happens.
+*/
+module('Fastboot | http interceptors', function(hooks) {
+  setup(hooks);
+  setupMirage(hooks);
+
+  test('it doesnt work if mirage blocks our http request to ember-cli', async function(assert) {
+    await visit('/');
+
+    
+
+  });
+
+});

--- a/tests/fastboot/mirage-interceptors-test.js
+++ b/tests/fastboot/mirage-interceptors-test.js
@@ -11,15 +11,15 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
   We want to provide a better error message when that happens.
 */
-module('Fastboot | http interceptors', function(hooks) {
+module('Fastboot | mirage interceptor', function(hooks) {
   setup(hooks);
   setupMirage(hooks);
 
   test('it doesnt work if mirage blocks our http request to ember-cli', async function(assert) {
-    await visit('/');
-
-    
-
+    assert.rejects(
+      visit('/'),
+      /It looks like Mirage is intercepting ember-cli-fastboot-testing's attempt to render \//
+    );
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,6 +1095,11 @@
     "@webassemblyjs/wast-parser" "1.7.11"
     "@xtuc/long" "4.2.1"
 
+"@xg-wang/whatwg-fetch@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@xg-wang/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#f7b222c012a238e7d6e89ed3d72a1e0edb58453d"
+  integrity sha512-ULtqA6L75RLzTNW68IiOja0XYv4Ebc3OGMzfia1xxSEMpD0mk/pMvkQX0vbCFyQmKc5xGp80Ms2WiSlXLh8hbA==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -2923,6 +2928,26 @@ broccoli-stew@^2.0.0:
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.0"
 
+broccoli-stew@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.1.0.tgz#ba73add17fda3b9b01d8cfb343a8b613b7136a0a"
+  integrity sha512-tgCkuTWYl4uf7k7ib2D79KFEj2hCgnTUNPMnrCoAha0/4bywcNccmaZVWtL9Ex37yX5h5eAbnM/ak2ULoMwSSw==
+  dependencies:
+    broccoli-debug "^0.6.5"
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^3.0.1"
+    broccoli-persistent-filter "^2.1.1"
+    broccoli-plugin "^1.3.1"
+    chalk "^2.4.1"
+    debug "^3.1.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^6.0.1"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    rsvp "^4.8.4"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.3"
+
 broccoli-string-replace@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz#1ed92f85680af8d503023925e754e4e33676b91f"
@@ -3324,7 +3349,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -4602,7 +4627,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^6.16.0:
+ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -4852,6 +4877,29 @@ ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
   integrity sha1-ry5366XcsNd/MwjTpv19NFD25Tc=
+
+ember-cli-mirage@^0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.15.tgz#dcf878e785853232d8ac725bb425aa545da63e79"
+  integrity sha512-5wCycS40pkohNPaLcyCn5BUjJ/4PGK9lz6j1tftJms5tBQhSjkZ37+pfhVKh3iYSId/+z0RTxVknykQH4P0sQA==
+  dependencies:
+    "@xg-wang/whatwg-fetch" "^3.0.0"
+    broccoli-file-creator "^2.1.1"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^3.0.2"
+    broccoli-stew "^2.0.1"
+    broccoli-string-replace "^0.1.2"
+    chalk "^1.1.1"
+    ember-auto-import "^1.2.19"
+    ember-cli-babel "^6.16.0"
+    ember-cli-node-assets "^0.2.2"
+    ember-get-config "^0.2.2"
+    ember-inflector "^2.0.0 || ^3.0.0"
+    fake-xml-http-request "^2.0.0"
+    faker "^3.0.0"
+    lodash "^4.17.11"
+    pretender "2.1.1"
+    route-recognizer "^0.3.4"
 
 ember-cli-node-assets@^0.2.2:
   version "0.2.2"
@@ -5251,6 +5299,14 @@ ember-fetch@^6.2.0, ember-fetch@^6.4.0:
     node-fetch "^2.3.0"
     whatwg-fetch "^3.0.0"
 
+ember-get-config@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
+
 ember-getowner-polyfill@^2.0.1, ember-getowner-polyfill@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
@@ -5282,7 +5338,7 @@ ember-ignore-children-helper@^1.0.1:
   dependencies:
     ember-cli-babel "^6.8.2"
 
-ember-inflector@^3.0.0:
+"ember-inflector@^2.0.0 || ^3.0.0", ember-inflector@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.0.tgz#7e1ee8aaa0fa773ba0905d8b7c0786354d890ee1"
   integrity sha512-tLWfYolZAkLnkTvvBkjizy4Wmj8yI8wqHZFK+leh0iScHiC3r1Yh5C4qO+OMGiBTMLwfTy+YqVoE/Nu3hGNkcA==
@@ -6031,6 +6087,16 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+fake-xml-http-request@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.0.0.tgz#41a92f0ca539477700cb1dafd2df251d55dac8ff"
+  integrity sha512-UjNnynb6eLAB0lyh2PlTEkjRJORnNsVF1hbzU+PQv89/cyBV9GDRCy7JAcLQgeCLYT+3kaumWWZKEJvbaK74eQ==
+
+faker@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-3.1.0.tgz#0f908faf4e6ec02524e54a57e432c5c013e08c9f"
+  integrity sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -9928,6 +9994,15 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+pretender@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.1.tgz#5085f0a1272c31d5b57c488386f69e6ca207cb35"
+  integrity sha512-IkidsJzaroAanw3I43tKCFm2xCpurkQr9aPXv5/jpN+LfCwDaeI8rngVWtQZTx4qqbhc5zJspnLHJ4N/25KvDQ==
+  dependencies:
+    "@xg-wang/whatwg-fetch" "^3.0.0"
+    fake-xml-http-request "^2.0.0"
+    route-recognizer "^0.3.3"
+
 pretty-ms@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-3.2.0.tgz#87a8feaf27fc18414d75441467d411d6e6098a25"
@@ -10681,6 +10756,11 @@ rollup@^0.57.1:
     rollup-pluginutils "^2.0.1"
     signal-exit "^3.0.2"
     sourcemap-codec "^1.4.1"
+
+route-recognizer@^0.3.3, route-recognizer@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
+  integrity sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==
 
 rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9994,7 +9994,7 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-pretender@2.1.1:
+pretender@2.1.1, pretender@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.1.tgz#5085f0a1272c31d5b57c488386f69e6ca207cb35"
   integrity sha512-IkidsJzaroAanw3I43tKCFm2xCpurkQr9aPXv5/jpN+LfCwDaeI8rngVWtQZTx4qqbhc5zJspnLHJ4N/25KvDQ==


### PR DESCRIPTION
If ECFT can't talk to the FastBoot instance then we'll display a nice error message. This is helpful if folks start running client side mirage inside of FastBoot tests, which won't work.

See https://github.com/embermap/ember-cli-fastboot-testing/issues/2