### PR TITLE
Add an echo endpoint for testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,7 @@ module.exports = {
 
   _fastbootRenderingMiddleware(app) {
 
-    app.use(bodyParser.json());
-    app.post('/__mock-request', (req, res) => {
+    app.post('/__mock-request', bodyParser.json(), (req, res) => {
       let mock = nock(req.headers.origin)
         .persist()
         .intercept(req.body.path, req.body.method)
@@ -118,6 +117,13 @@ module.exports = {
           res.json({ err: jsonError });
         });
     });
+
+    if (this.app.name === "dummy") {
+      // our dummy app has an echo endpoint!
+      app.post('/fastboot-testing/echo', bodyParser.text(), (req, res) => {
+        res.send(req.body);
+      });
+    }
   },
 
   postBuild(result) {

--- a/tests/dummy/app/pods/examples/network/other/echo/controller.js
+++ b/tests/dummy/app/pods/examples/network/other/echo/controller.js
@@ -1,0 +1,5 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['message']
+});

--- a/tests/dummy/app/pods/examples/network/other/echo/route.js
+++ b/tests/dummy/app/pods/examples/network/other/echo/route.js
@@ -1,0 +1,20 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+
+export default Route.extend({
+
+  // this endpoint is defined in index.js, it's used to represent
+  // a url that ember-cli might already have in it's express router.
+
+  // we should be able to post a body to this echo endpoint and
+  // get a reply back.
+  model(params) {
+    return fetch('/fastboot-testing/echo', {
+      method: 'POST',
+      body: params.message
+    }).then(response => {
+      return response.text();
+    });
+  }
+
+});

--- a/tests/dummy/app/pods/examples/network/other/echo/template.hbs
+++ b/tests/dummy/app/pods/examples/network/other/echo/template.hbs
@@ -1,0 +1,1 @@
+<div data-test-id="echo">{{model}}</div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -36,6 +36,7 @@ Router.map(function() {
       this.route('other', function() {
         this.route('get-request');
         this.route('post-request');
+        this.route('echo');
       });
     });
 

--- a/tests/fastboot/network-mocking-test.js
+++ b/tests/fastboot/network-mocking-test.js
@@ -4,6 +4,11 @@ import { setup, visit, mockServer } from 'ember-cli-fastboot-testing/test-suppor
 module('Fastboot | network mocking', function(hooks) {
   setup(hooks);
 
+  test('it will not change an endpoint that already exists', async function(assert) {
+    await visit('/examples/network/other/echo?message=hello%20world');
+    assert.dom('[data-test-id="echo"]').hasText("hello world");
+  });
+
   test('it can mock an array of models', async function(assert) {
     await mockServer.get('/api/posts', {
       data: [


### PR DESCRIPTION
This is used to represent some other text based endpoints that ember-cli might already have.

I believe this fixes a bug where our bodyParser location was too aggressive.