### PR TITLE
Remove the word "test" from test name in blueprint

### DIFF
--- a/blueprints/fastboot-test/files/tests/fastboot/__name__-test.js
+++ b/blueprints/fastboot-test/files/tests/fastboot/__name__-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setup, visit, /* mockServer */ } from 'ember-cli-fastboot-testing/test-support';
 
-module('FastBoot | <%= dasherizedModuleName %> test', function(hooks) {
+module('FastBoot | <%= dasherizedModuleName %>', function(hooks) {
   setup(hooks);
 
   test('it renders a page...', async function(assert) {


### PR DESCRIPTION
Other ember tests generated via `ember g` do not include the word "test" in the name within the module string.