### PR TITLE
Guard against this.app being undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = {
         });
     });
 
-    if (this.app.name === "dummy") {
+    if (this.app && this.app.name === "dummy") {
       // our dummy app has an echo endpoint!
       app.post('/fastboot-testing/echo', bodyParser.text(), (req, res) => {
         res.send(req.body);


### PR DESCRIPTION
This prevents an error from being thrown if `this.app` is undefined.

I'm not sure why, but when running tests using `path=dist`, `this.app` is undefined at this line of code.

#### Specific repro steps - from consuming application:

`ember build --environment test`
`ember test --path dist`

Get: `Cannot read property 'name' of undefined`