### PR TITLE
Reduce the number of test runs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,7 @@ jobs:
       env: NAME=floating dependencies
       install: yarn install --no-lockfile --non-interactive
       script: yarn test
-
-    - stage: versioned tests
-      env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.8
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,17 +47,13 @@ jobs:
 
     - stage: versioned tests
       env: EMBER_TRY_SCENARIO=ember-lts-2.8
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
-    - env: EMBER_TRY_SCENARIO=fastboot-1.2
     - env: EMBER_TRY_SCENARIO=fastboot-2.0
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-default
 
     - stage: deploy
       if: (branch = master OR tag IS present) AND type = push

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -29,22 +29,6 @@ module.exports = function() {
           }
         },
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
-          name: 'ember-lts-2.16',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.16.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.18',
           npm: {
             devDependencies: {
@@ -65,15 +49,6 @@ module.exports = function() {
           npm: {
             devDependencies: {
               'ember-source': '~3.8.0'
-            }
-          }
-        },
-        {
-          name: 'fastboot-1.2',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.8.0',
-              'fastboot': '^1.2.1'
             }
           }
         },
@@ -108,12 +83,6 @@ module.exports = function() {
             devDependencies: {
               'ember-source': urls[2]
             }
-          }
-        },
-        {
-          name: 'ember-default',
-          npm: {
-            devDependencies: {}
           }
         }
       ]


### PR DESCRIPTION
IMO Travis takes way too long to complete all tests for a PR, e.g.
"Ran for 34 min 15 sec
 Total time 56 min 55 sec"

I believe we could cut some of the ember-try scenarios:

* `fastboot-1.2`: was essentially the same as `ember-lts-3.8` because `fastboot` in package.json is already using `^1.2.1`
* `ember-default`: was the same as `stage: test`
* `ember-lts-2.12`, `ember-lts-2.16`: seems reasonable to limit ember 2.x tests to the oldest supported and the latest LTS versions
