### PR TITLE
Drop the node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 sudo: false
 dist: trusty
 node_js:
-  - "6"
+  - "8"
 
 addons:
   chrome: stable

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "qunit-dom": "^0.6.2"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "resolutions": {
     "**/tough-cookie": "~2.4.0"


### PR DESCRIPTION
ECFT didn't really support node 6, at least not in development/test environments.
CI tests were passing because of they are targeting the IE 11, just like production builds (see: [targets.js](https://github.com/embermap/ember-cli-fastboot-testing/blob/da49865a25a40d2ea7ba53079e2ccf7b37f2643f/tests/dummy/config/targets.js#L12-L14)).