### PR TITLE
Refactor the code to allow importing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,8 @@ module.exports = {
         'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js',
-        'node/**/*.js'
+        'node/**/*.js',
+        'lib/**/*.js'
       ],
       excludedFiles: [
         'addon/**',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,107 @@
+'use strict';
+
+let fs = require('fs');
+let path = require('path');
+let nock = require('nock');
+let url = require('url');
+let JSONfn = require('json-fn');
+let FastBoot = require('fastboot');
+let bodyParser = require('body-parser');
+
+function createMockRequest(app) {
+  app.post('/__mock-request', bodyParser.json({ limit: '50mb' }), (req, res) => {
+    let mock = nock(req.headers.origin)
+      .persist()
+      .intercept(req.body.path, req.body.method)
+      .reply(req.body.statusCode, req.body.response);
+
+    res.json({ mocks: mock.pendingMocks() });
+  });
+}
+
+function createCleanUpMocks(app) {
+  app.use('/__cleanup-mocks', (req, res) => {
+    nock.cleanAll()
+
+    res.json({ ok: true });
+  });
+}
+
+function createFastbootTest(app, callback) {
+  app.post('/__fastboot-testing', bodyParser.json(), (req, res) => {
+    let urlToVisit = decodeURIComponent(req.body.url);
+    let parsed = url.parse(urlToVisit, true);
+
+    let headers = Object.assign(
+      {},
+      req.headers,
+      JSONfn.parse(req.body.options).headers || {}
+    );
+
+    let defaultOptions = {
+      request: {
+        method: 'GET',
+        protocol: 'http',
+        url: parsed.path,
+        query: parsed.query,
+        headers,
+      },
+      response: {},
+    };
+
+    let options = Object.assign(defaultOptions, JSONfn.parse(req.body.options));
+
+    res.set('x-fastboot-testing', true);
+
+    callback({ req, res, options, urlToVisit });
+  });
+}
+  
+function createFastbootEcho(app) {
+  app.post('/fastboot-testing/echo', bodyParser.text(), (req, res) => {
+    res.send(req.body);
+  });
+}
+
+function reloadServer(fastboot, distPath, options) {
+  fastboot.reload({ distPath });
+  options.setupFastboot(fastboot);
+}
+
+function createServer(distPath, pkg) {
+  let options = makeFastbootTestingConfig({ distPath }, pkg);
+  let fastboot = new FastBoot(options);
+  options.setupFastboot(fastboot);
+
+  return fastboot;
+}
+
+function makeFastbootTestingConfig(config, pkg) {
+  let defaults = {
+    setupFastboot() {}
+  };
+
+  let configPath = 'config';
+
+  if (pkg['ember-addon'] && pkg['ember-addon']['configPath']) {
+    configPath = pkg['ember-addon']['configPath'];
+  }
+
+  let fastbootTestConfigPath = path.resolve(configPath, 'fastboot-testing.js');
+
+  let customized = fs.existsSync(fastbootTestConfigPath) ?
+    require(fastbootTestConfigPath) :
+    {};
+
+  return Object.assign({}, config, defaults, customized);
+}
+
+module.exports = {
+  createMockRequest,
+  createCleanUpMocks,
+  createFastbootTest,
+  createFastbootEcho,
+  reloadServer,
+  createServer,
+  makeFastbootTestingConfig
+};


### PR DESCRIPTION
Internally we are using this library for our SSR testing. However, one of our apps is actually a combination of 2 ember apps and doesn't play nicely with this addon (the dist path points to the parent "blank" app, we need multiple fastboot instances, etc). For this app we still want to use most of the logic from this addon but found it hard to import the logic into say an in repo addon. This PR breaks up the code such that it can be more easily imported / extended so that we can still share most of the logic. The intent of this PR is that no underlining logic has changed and is purely abstracting bits into helper functions.