### PR TITLE
fix FastBoot.distPath being deleted before tests complete, fixes #207

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ module.exports = {
   outputReady(result) {
     // NOTE: result.directory is not updated and still references the same path as postBuild hook (this might be a bug in ember-cli)
     // Set the distPath to the "final" outputPath, where EMBER_CLI_TEST_OUTPUT is the path passed to testem (set by ember-cli).
-    let distPath = process.env.EMBER_CLI_TEST_OUTPUT;
+    // We fall back to result.directory if EMBER_CLI_TEST_OUTPUT is not set.
+    let distPath = process.env.EMBER_CLI_TEST_OUTPUT || result.directory;
     let { pkg } = this.project;
 
     if (this.fastboot) {

--- a/index.js
+++ b/index.js
@@ -47,8 +47,11 @@ module.exports = {
     this._fastbootRenderingMiddleware(app);
   },
 
-  postBuild(result) {
-    let distPath = result.directory;
+  // we have to use the outputReady hook to ensure that ember-cli has finished copying the contents to the outputPath directory
+  outputReady(result) {
+    // NOTE: result.directory is not updated and still references the same path as postBuild hook (this might be a bug in ember-cli)
+    // Set the distPath to the "final" outputPath, where EMBER_CLI_TEST_OUTPUT is the path passed to testem (set by ember-cli).
+    let distPath = process.env.EMBER_CLI_TEST_OUTPUT;
     let { pkg } = this.project;
 
     if (this.fastboot) {
@@ -73,7 +76,7 @@ module.exports = {
           return res.json({ err: 'no path found' });
         }
       }
-  
+
       this.fastboot
         .visit(urlToVisit, options)
         .then(page => {
@@ -90,11 +93,11 @@ module.exports = {
         .catch(err => {
           let errorObject;
           let jsonError = {};
-  
+
           errorObject = (typeof err === 'string') ?
             new Error(err) :
             err;
-  
+
           // we need to copy these properties off the error
           // object into a pojo that can be serialized and
           // sent over the wire to the test runner.
@@ -107,9 +110,9 @@ module.exports = {
             'number',
             'stack'
           ];
-  
+
           errorProps.forEach(key => jsonError[key] = errorObject[key]);
-  
+
           res.json({ err: jsonError });
         });
     });

--- a/testem.js
+++ b/testem.js
@@ -12,7 +12,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
This addresses a bug where the broccoli tmp directory may be deleted before tests are finished executing.

This issue manifests itself in that `FastBoot.distPath` references a path that may have already been deleted from disk.

The ember-cli lifecycle for `ember test` invoke BuildTask > builder.cleanup > TestTask. Where build.cleanup will start the process of cleaning up broccoli temp dirs.

The first part of the fix is to move from `postBuild` hook to `outputReady` hook. The `outputReady` hook runs after the content has been copied from the broccoli temp dir into the final target directory.

The second part of the fix is to use `process.env.EMBER_CLI_TEST_OUTPUT` for our file path. This is the same path that is ultimately used by the testem runner.

Since this has to do specifically with ember-cli lifecycle hooks, I'm not sure how to write a test case for this, so sorry for the lack of tests here. But I am able to confirm the fix in a local app.

Also had to remove `--disable-gpu` from testem flags to get `ember test` running again (see ember-cli/ember-cli/pull/8774 for more context).

**References:**
- https://ember-cli.com/api/classes/Addon.html#method_outputReady
- [ember-cli/lib/models/builder.js](https://github.com/ember-cli/ember-cli/blob/3106301154f397d151f6f56007ab4317a5498fa5/lib/models/builder.js#L219-L224)
- [ember-cli/lib/commands/test.js](https://github.com/ember-cli/ember-cli/blob/b0e01db47ae7e369d4acb937d0d580dae80e9d84/lib/commands/test.js#L164)
- ember-cli/ember-cli/pull/8774