### PR TITLE
Add mockServer origin override

### DIFF
--- a/addon-test-support/-private/mock-server.js
+++ b/addon-test-support/-private/mock-server.js
@@ -1,6 +1,14 @@
 import { fetch } from 'whatwg-fetch';
 
 let createMock = async function(path, method, statusCode, response) {
+  let origin = false;
+
+  if (path.startsWith('http')) {
+    const url = new URL(path);
+    origin = url.origin;
+    path = `${url.pathname}${url.search}`;
+  }
+
   return await fetch('/__mock-request', {
     method: 'post',
     headers: {
@@ -10,7 +18,8 @@ let createMock = async function(path, method, statusCode, response) {
       path,
       method,
       statusCode,
-      response
+      response,
+      origin
     }),
   });
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,8 @@ let bodyParser = require('body-parser');
 
 function createMockRequest(app) {
   app.post('/__mock-request', bodyParser.json({ limit: '50mb' }), (req, res) => {
-    let mock = nock(req.headers.origin)
+    const requestOrigin = req.body.origin || req.headers.origin;
+    let mock = nock(requestOrigin)
       .persist()
       .intercept(req.body.path, req.body.method)
       .reply(req.body.statusCode, req.body.response);
@@ -56,7 +57,7 @@ function createFastbootTest(app, callback) {
     callback({ req, res, options, urlToVisit });
   });
 }
-  
+
 function createFastbootEcho(app) {
   app.post('/fastboot-testing/echo', bodyParser.text(), (req, res) => {
     res.send(req.body);

--- a/tests/dummy/app/pods/docs/network-mocking/template.md
+++ b/tests/dummy/app/pods/docs/network-mocking/template.md
@@ -51,6 +51,28 @@ test('it renders the 404 page when it cannot fetch a note', async function(asser
 });
 ```
 
+By default, passing just a path to `mockServer` will use the current host running your app.
+
+Some implementations require a different origin for `mockServer` calls. In that case, you can override the default host by including the hostname with the path.
+
+```js
+test('it makes a call to a different host', async function(assert) {
+  await mockServer.get('http://localhost:3000/api/notes/1', {
+    data: {
+      type: 'note',
+      id: '1',
+      attributes: {
+        title: 'Hello world!'
+      }
+    }
+  });
+
+  await visit('/notes/1');
+
+  assert.dom('[data-test-id="page-not-found"]').exists();
+});
+```
+
 The `mockServer` also exposes `post`, `patch`, `put`, and `delete` mocking methods.
 
 ## Video

--- a/tests/dummy/app/pods/examples/network/other/origin-override/route.js
+++ b/tests/dummy/app/pods/examples/network/other/origin-override/route.js
@@ -1,0 +1,13 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+import config from 'dummy/config/environment';
+
+export default Route.extend({
+
+  async model() {
+    const { originForOverride } = config;
+    let response = await fetch(`${originForOverride}/api/notes`, { method: 'get' });
+    return await response.json();
+  }
+
+});

--- a/tests/dummy/app/pods/examples/network/other/origin-override/template.hbs
+++ b/tests/dummy/app/pods/examples/network/other/origin-override/template.hbs
@@ -1,0 +1,7 @@
+The data loaded from the server is:
+
+{{#each model as |note|}}
+  <div data-test-id="title-{{note.id}}">
+    {{note.title}}
+  </div>
+{{/each}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -39,6 +39,7 @@ Router.map(function() {
       this.route('other', function() {
         this.route('get-request');
         this.route('post-request');
+        this.route('origin-override');
         this.route('echo');
       });
     });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function(environment) {
     environment,
     rootURL: '/',
     locationType: 'auto',
+    originForOverride: 'http://localhost:3000',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tests/fastboot/network-mocking-test.js
+++ b/tests/fastboot/network-mocking-test.js
@@ -4,6 +4,7 @@ import {
   visit,
   mockServer
 } from "ember-cli-fastboot-testing/test-support";
+import config from 'dummy/config/environment';
 
 module("Fastboot | network mocking", function(hooks) {
   setup(hooks);
@@ -95,5 +96,15 @@ module("Fastboot | network mocking", function(hooks) {
     await visit("/examples/network/other/get-request");
 
     assert.dom('[data-test-id="title-1"]').exists();
+  });
+
+  test("it can override the origin on a mock response", async function(assert) {
+    const { originForOverride } = config;
+
+    await mockServer.get(`${originForOverride}/api/notes`, [{ id: 1, title: "get note" }]);
+
+    await visit("/examples/network/other/origin-override");
+
+    assert.dom('[data-test-id="title-1"]').hasText("get note");
   });
 });


### PR DESCRIPTION
This PR is in response to my own Issue provided: https://github.com/embermap/ember-cli-fastboot-testing/issues/310

Basically, I want to permit users to specify the host when creating `mockServer`.

This is useful in many cases and I believe would set the groundwork for several of the outstanding open issues.