### PR TITLE
Move isEnabled intention to included hook; fix ember-auto-import conflicts

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,17 +19,12 @@ module.exports = {
     return false;
   },
 
-  isEnabled() {
-    // enable this addon if were building for the dummy
-    // app. that's because this is most likely an addon docs
-    // build and we need this addon enabled for our docs
-    // to deploy correctly.
-    return this.app.name === "dummy" ||
-      this.app.env !== "production";
-  },
-
   included() {
     this._super.included.apply(this, arguments);
+
+    const isEnabled = this.app.name === "dummy" || this.app.env !== "production";
+
+    if (!isEnabled) return;
 
     try {
       resolve.sync('ember-cli-fastboot/package.json', { basedir: this.project.root });


### PR DESCRIPTION
In reference to https://github.com/ef4/ember-auto-import/issues/340
When using this addon, fastboot breaks with ember-auto-import past v 1.6.0 because the `isEnabled` hook resolves to false.

I've tried to keep the spirit/intent of the former use of the `isEnabled` hook and just block the file sync in the case of a production environment, since this addon and its dependencies are not needed in the production environment.

I've tested:

**Locally**  
All our fastboot tests using ember-cli-fastboot-testing run and pass just as before.


**Deployed**  
Previous to this change, an update to ember-auto-import past v1.6.0 broke and would error on the server. With this change we can update to v1.10.1 and have no issues.


Would love to discuss and have some additional folks test for their environments to see if this works well.

**Additionally**
Should consider updating ember-auto-import. Current version is at 1.2.15 and current is 1.10.1
