### PR TITLE
Remove Ember 2.18 from ember-try; Reinstate deploy via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,18 @@ jobs:
       env: NAME=deploy
       script: node_modules/.bin/ember deploy production
 
+    - stage: npm release
+      install: skip
+      before_script: skip
+      script: skip
+      deploy:
+        provider: npm
+        email: ryanto@gmail.com
+        api_key:
+          secure: yblp7SWj5oifZ2iywuYeBUTL8eVHanSiGrXwH7zYa7Z+ORr3kFKHJIsWNJo/8jbcb7SwqVv8RbROfkBEFt+VxdpDos2Y/DgnBA06OoHdmdOOAc8d1gFpsHdUDdUUEPXEv1ZKR0+dh7Hcv+qoUHuIkSqNVq8STDkCAHFy7gIEM+sGfJ+9eZZV8HzWe2u61QUilazU8AkASZBICXq2t3Na6PMyoJKDxoVbvUHCdTQywy3i9HhoedSEjoLt1l6x4bhaJ/fvmnf0x2ILI6b8epwSpeg2sgcsoYC5tI9mwNq1zzALiXUDYnCYtV8zAlFWH+bu4QS5nphiHMIkR1wUMyOkS/tG5kKeeAyDEQkJtbqH3en/P00D94rQVZ0XytSQdaIwzA6z73SFd1rdn2jVX4Szm6f37u+E17H7TdfuB+Pzqs3JeeHgOVcIBFE7nO0IwzPjc0SG2Buq3UU2tQjx52A7VTgjsgZFcovVbIBqLVLk7Duj0BTc2zhVluiVlqLjloFrpNMeBPMtVXPvHywhJI19JOoz2RK2KgpMcasQNCbDf+eissIVH6WuRfjhfvxkeR2dTXPAJxHhNFJAqkJbHKmPXyXfSYPdv2F5LdMIJPEAf4aIOdr1v/AjAuM6caNFL7bU2sUyPjt7jI5XgykdQb2BkdT4ZO7Tpm9UGrRpZOqhjIE=
+        on:
+          tags: true
+          repo: embermap/ember-cli-fastboot-testing
+
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,15 +12,6 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
-          name: "ember-lts-2.18",
-          npm: {
-            devDependencies: {
-              "ember-source": "~2.18.0",
-              "ember-data": "~2.18.0"
-            }
-          }
-        },
-        {
           name: "ember-lts-3.4",
           npm: {
             devDependencies: {


### PR DESCRIPTION
@ryanto Here is the PR discussed yesterday.
Let's see how CI runs it in the PR.

I saw several dependabot PRs merged. Still no luck with ember-try locally.
Will work on that this week.