### PR TITLE
Add headers to mocked responses

### DIFF
--- a/addon-test-support/-private/mock-server.js
+++ b/addon-test-support/-private/mock-server.js
@@ -1,6 +1,6 @@
 import { fetch } from 'whatwg-fetch';
 
-let createMock = function(path, method, statusCode, response) {
+let createMock = function(path, method, statusCode, response, responseHeaders) {
   let origin = false;
 
   if (path.startsWith('http')) {
@@ -19,30 +19,31 @@ let createMock = function(path, method, statusCode, response) {
       method,
       statusCode,
       response,
+      responseHeaders,
       origin
     }),
   });
 }
 
 export let mockServer = {
-  get(path, response, status = 200) {
-    return createMock(path, "GET", status, response);
+  get(path, response, status = 200, responseHeaders) {
+    return createMock(path, "GET", status, response, responseHeaders);
   },
 
-  post(path, response, status = 200) {
-    return createMock(path, "POST", status, response);
+  post(path, response, status = 200, responseHeaders) {
+    return createMock(path, "POST", status, response, responseHeaders);
   },
 
-  patch(path, response, status = 200) {
-    return createMock(path, "PATCH", status, response);
+  patch(path, response, status = 200, responseHeaders) {
+    return createMock(path, "PATCH", status, response, responseHeaders);
   },
 
-  put(path, response, status = 200) {
-    return createMock(path, "PUT", status, response);
+  put(path, response, status = 200, responseHeaders) {
+    return createMock(path, "PUT", status, response, responseHeaders);
   },
 
-  delete(path, response, status = 200) {
-    return createMock(path, "DELETE", status, response);
+  delete(path, response, status = 200, responseHeaders) {
+    return createMock(path, "DELETE", status, response, responseHeaders);
   },
 
   cleanUp() {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,7 @@ function createMockRequest(app) {
     let mock = nock(requestOrigin)
       .persist()
       .intercept(req.body.path, req.body.method)
-      .reply(req.body.statusCode, req.body.response);
+      .reply(req.body.statusCode, req.body.response, req.body.responseHeaders);
 
     res.json({ mocks: mock.pendingMocks() });
   });

--- a/tests/dummy/app/pods/examples/network/other/headers/route.js
+++ b/tests/dummy/app/pods/examples/network/other/headers/route.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+
+export default Route.extend({
+
+  async model() {
+    let response = await fetch('/api/notes');
+    const headers = await response.headers;
+    return headers.get('x-test');
+  }
+
+});

--- a/tests/dummy/app/pods/examples/network/other/headers/template.hbs
+++ b/tests/dummy/app/pods/examples/network/other/headers/template.hbs
@@ -1,0 +1,3 @@
+<div data-test-id="headers">
+  {{model}}
+</div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -38,6 +38,7 @@ Router.map(function() {
 
       this.route('other', function() {
         this.route('get-request');
+        this.route('headers');
         this.route('post-request');
         this.route('origin-override');
         this.route('echo');

--- a/tests/fastboot/network-mocking-test.js
+++ b/tests/fastboot/network-mocking-test.js
@@ -107,4 +107,18 @@ module("Fastboot | network mocking", function(hooks) {
 
     assert.dom('[data-test-id="title-1"]').hasText("get note");
   });
+
+  test("it can add headers a mock response", async function(assert) {
+
+    await mockServer.get(
+      '/api/notes',
+      { data: [] },
+      200,
+      {'x-test': 'foo'}
+    );
+
+    await visit("/examples/network/other/headers");
+
+    assert.dom('[data-test-id="headers"]').hasText("foo");
+  });
 });


### PR DESCRIPTION
Add the ability to specify headers to be returned by a mocked response.
My team found several use cases where this is needed for FastBoot acceptance testing because we have logic similar to one described in [accessing-metadata-from-ember-data-s-findrecord-method](https://embermap.com/video/accessing-metadata-from-ember-data-s-findrecord-method)