### PR TITLE
Revert fastboot as peerDependency, allows v3 and v4 instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "body-parser": "^1.20.0",
     "ember-auto-import": "^2.6.1",
     "ember-cli-babel": "^7.26.11",
+    "fastboot": "^3.0.3 || ^4.1.1",
     "json-fn": "^1.1.1",
     "minimist": "^1.2.6",
     "nock": "^13.2.4",
@@ -50,7 +51,6 @@
     "broccoli-plugin": "^4.0.7",
     "broccoli-stew": "^3.0.0",
     "concurrently": "^8.0.1",
-    "fastboot": "^4.1.0",
     "ember-cli": "~4.11.0",
     "ember-cli-addon-docs": "github:ember-learn/ember-cli-addon-docs#eb825bcc1e721dbebc73e5dbd98db2ebb3026dd3",
     "ember-cli-addon-docs-yuidoc": "^1.0.0",
@@ -92,8 +92,7 @@
     "webpack": "^5.75.0"
   },
   "peerDependencies": {
-    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0",
-    "fastboot": "*"
+    "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "12.* || 14.* || 16.* || >= 18"

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -34,32 +34,38 @@ module.exports = async function () {
       {
         name: 'fastboot-1.2',
         npm: {
+          dependencies: {
+            fastboot: '~1.2.1',
+          },
           devDependencies: {
             'ember-source': '~3.20.7',
             'ember-data': '~3.20.5',
             'ember-qunit': '^5.1.5',
-            fastboot: '~1.2.1',
           },
         },
       },
       {
         name: 'fastboot-2.0',
         npm: {
+          dependencies: {
+            fastboot: '~2.0.3',
+          },
           devDependencies: {
             'ember-cli-fastboot': '^2.0.0',
             'ember-data': '~3.20.5',
             'ember-qunit': '^5.1.5',
             'ember-source': '~3.20.7',
-            fastboot: '~2.0.3',
           },
         },
       },
       {
         name: 'fastboot-3.0',
         npm: {
+          dependencies: {
+            fastboot: '^3.0.0',
+          },
           devDependencies: {
             'ember-cli-fastboot': '^3.0.0',
-            fastboot: '^3.0.0',
           },
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7627,10 +7627,23 @@ fastboot-transform@^0.1.3:
     broccoli-stew "^1.5.0"
     convert-source-map "^1.5.1"
 
-fastboot@4.1.0, fastboot@^4.1.0:
+fastboot@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-4.1.0.tgz#4c2f62841d80b0a246e38adb3c35b626e2f42087"
   integrity sha512-NoUUiWhLS4JfrYiHmbRjqqWmzttO+6hVyt+CawsZCg79ljTGAIhPThy8cxg11yiDNiaM9EY3kocWZrCMUM7o4g==
+  dependencies:
+    chalk "^4.1.2"
+    cookie "^0.4.1"
+    debug "^4.3.3"
+    jsdom "^19.0.0"
+    resolve "^1.22.0"
+    simple-dom "^1.4.0"
+    source-map-support "^0.5.21"
+
+"fastboot@^3.0.3 || ^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-4.1.1.tgz#b686dc522ef805557ff76ded23328c486991cbaa"
+  integrity sha512-XG7YprsAuAGZrUDhmJ0NFuEP0gpWg9LZwGWSS1I5+f0ETHKPWqb4x59sN2rU1nvCEETBK70z68tLsWsl9daomg==
   dependencies:
     chalk "^4.1.2"
     cookie "^0.4.1"


### PR DESCRIPTION
This reverts #765 and instead allows either v3 or v4 of `fastboot` package.

problem with #765 is that consuming applications usually do not specify `fastboot` as dependency hence this may break expectations and come as (an unnecessary) surprise