### PR TITLE
Ensure origin host is extracted in cli mode

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,7 +40,10 @@ function createCleanUpMocks(app) {
 function createFastbootTest(app, callback) {
   app.post('/__fastboot-testing', bodyParser.json(), (req, res) => {
     const urlToVisit = decodeURIComponent(req.body.url);
-    const parsed = new URL(urlToVisit, req.headers.origin);
+    const origin = req.headers.origin
+      ? req.headers.origin // Available when tests are run with `--server`
+      : new URL(req.headers.referer).origin; // Otherwise extract origin from referer
+    const parsed = new URL(urlToVisit, origin);
 
     const headers = Object.assign(
       {},


### PR DESCRIPTION
Tried to do this dynamically and make no assumptions about the host or port which the tests may running on.

Tested locally via `yarn link`. Wasn't able to run the tests locally so not sure how CI will go.

Fixes #601