### PR TITLE
Drop support for Node.js v16 and below

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: yarn
 
       - name: Install Dependencies
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: yarn
 
       - name: Install Dependencies
@@ -62,7 +62,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: yarn
 
       - name: Install Dependencies
@@ -99,7 +99,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: yarn
 
       - name: Install Dependencies
@@ -119,7 +119,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
           cache: yarn
 
       - name: Install Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 18.x
           cache: yarn
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+This addon is setup to publish to npm when GitHub release gets created, see [publish](./.github/workflows/publish.yml)
+GitHub workflow.
+
+Hence, sequence of steps should be:
+
+- `GITHUB_AUTH=abc npx lerna-changelog` to create changelog
+- `npm version [major | minor | patch]` to tag the release
+- `git push` to push code changes
+- `git push origin tag <tag_name>` to push the git tag
+- Create new GitHub release from newly published tag https://github.com/embermap/ember-cli-fastboot-testing/releases/new

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@ember/test-helpers": ">= 3.0.0"
   },
   "engines": {
-    "node": "12.* || 14.* || 16.* || >= 18"
+    "node": "18.* || 20.* || >= 22"
   },
   "ember": {
     "edition": "octane"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,9 +4672,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464:
-  version "1.0.30001470"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz#09c8e87c711f75ff5d39804db2613dd593feeb10"
-  integrity sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==
+  version "1.0.30001663"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz"
+  integrity sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This also technically breaks support for now unsupported Node.js versions 13, 15, 17, 19, 21.